### PR TITLE
Fix question text not show image/files.

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -49,7 +49,7 @@ class qtype_crossword_renderer extends qtype_with_combined_feedback_renderer {
             'orientation' => $orientationvalue,
             'readonly' => false
         ];
-        $data['questiontext'] = $question->questiontext;
+        $data['questiontext'] = $question->format_questiontext($qa);
         foreach ($question->answers as $key => $answer) {
             $orientation = 'across';
             $fieldname = 'sub' . $key;

--- a/tests/behat/preview.feature
+++ b/tests/behat/preview.feature
@@ -22,6 +22,7 @@ Feature: Preview a Crossword question
       | Test questions   | crossword | crossword-001 | normal              |
       | Test questions   | crossword | crossword-002 | unicode             |
       | Test questions   | crossword | crossword-003 | different_codepoint |
+      | Test questions   | crossword | crossword-004 | sampleimage         |
 
   @javascript @_switch_window
   Scenario: Preview a Crossword question and submit a correct response.
@@ -35,6 +36,12 @@ Feature: Preview a Crossword question
     And I press "Submit and finish"
     Then I should see "Correct feedback"
     And I should see "Answer 1: BRAZIL, Answer 2: PARIS, Answer 3: ITALY"
+
+  @javascript @_switch_window
+  Scenario: Preview a Crossword question with sample image.
+    When I am on the "crossword-004" "core_question > preview" page logged in as teacher
+    Then "//img[@src='@@PLUGINFILE@@/test.jpg']" "xpath_element" should not exist
+    And "//img[contains(@src,'question/questiontext')]" "xpath_element" should exist
 
   @javascript @_switch_window
   Scenario: Preview a Crossword question and submit an partially correct response.

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -42,7 +42,7 @@ class qtype_crossword_test_helper extends question_test_helper {
      * @return array The test question array.
      */
     public function get_test_questions(): array {
-        return ['normal', 'unicode', 'different_codepoint'];
+        return ['normal', 'unicode', 'different_codepoint', 'sampleimage'];
     }
 
     /**
@@ -136,6 +136,18 @@ class qtype_crossword_test_helper extends question_test_helper {
         $fromform->startcolumn = [0, 2, 2];
         $fromform->numrows = 5;
         $fromform->numcolumns = 7;
+        return $fromform;
+    }
+
+    /**
+     * Makes a normal crossword question with a sample image in question text.
+     *
+     * @return qtype_crossword_question
+     */
+    public function get_crossword_question_form_data_sampleimage() {
+        $fromform = $this->get_crossword_question_form_data_normal();
+        $fromform->questiontext = ['text' => 'Cross word question text with sample image <img src="@@PLUGINFILE@@/test.jpg" />',
+            'format' => FORMAT_HTML];
         return $fromform;
     }
 


### PR DESCRIPTION
Hi @timhunt ,
we had forgotten to add the format_questiontext to our question text field so it is causing issues when we add images, videos, and files to our question text field.
so I have fixed the issue.
I can't find a good way to write the unit test for it since it is in the renderer so I write a behat scenario but I can't find a good way to check the image path so I use the css_element.
Could you please review it?
