### PR TITLE
Quiz\Crossword: question text not separate from content if it has a picture left-aligned

### DIFF
--- a/templates/crossword_clues.mustache
+++ b/templates/crossword_clues.mustache
@@ -55,7 +55,7 @@
     }
 }}
 
-<div class="qtext"> {{{ questiontext }}}</div>
+<div class="qtext clearfix"> {{{ questiontext }}}</div>
 <div class="qtype_crossword-grid-wrapper">
     <div class="row mx-auto my-3">
         <div class="col-12 wrap-crossword position-relative">


### PR DESCRIPTION
Hi @timhunt ,

Since moodle already has a class to support clear floating content. Just add this to the text div will fix this issue.
