### PR TITLE
Quiz\Crossword: Improve the way to draw the grid view

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -105,6 +105,9 @@
 .qtype_crossword-grid-wrapper .wrap-crossword #crossword .crossword-cell {
     cursor: pointer;
     fill: #fff;
+    stroke: #000;
+    stroke-width: 2px;
+    paint-order: stroke;
 }
 
 .qtype_crossword-grid-wrapper .wrap-crossword #crossword .crossword-grid-background {
@@ -120,7 +123,7 @@
 }
 
 .qtype_crossword-grid-wrapper .wrap-crossword #crossword .crossword-cell-number {
-    font-size: 0.625rem;
+    font-size: 0.5rem;
 }
 
 .qtype_crossword-grid-wrapper .wrap-crossword #crossword .crossword-hidden-input-wrapper {
@@ -151,6 +154,10 @@
     text-transform: uppercase;
     text-anchor: middle;
     caret-color: transparent;
+}
+
+body.gecko .qtype_crossword-grid-wrapper .wrap-crossword #crossword .crossword-hidden-input-wrapper input:focus {
+    outline-offset: -2px;
 }
 
 .qtype_crossword-grid-wrapper .wrap-clue .clue-id {


### PR DESCRIPTION
Hi @timhunt ,

I have added some CSS styling to change the way the crossword border is drawn to make sure it is working well with all browsers even when zooming.
Because we use stroke to draw the border, we need to set the outline-offset to so the focus is overflow when we focus the cell on Firefox.
body.gecko .qtype_crossword-grid-wrapper .wrap-crossword #crossword .crossword-hidden-input-wrapper input {
    outline-offset: -2px;
}

