### PR TITLE
clear wrong response when we have accent response

### DIFF
--- a/question.php
+++ b/question.php
@@ -233,14 +233,13 @@ class qtype_crossword_question extends question_graded_automatically {
                     return true;
                 }
             }
-        }
-
-        if ($component == 'question' && in_array($filearea,
+        } else if ($component === 'question' && in_array($filearea,
                 ['correctfeedback', 'partiallycorrectfeedback', 'incorrectfeedback'])) {
             return $this->check_combined_feedback_file_access($qa, $options, $filearea, $args);
+        } else if ($component === 'question' && $filearea === 'hint') {
+            return $this->check_hint_file_access($qa, $options, $args);
+        } else {
+            return parent::check_file_access($qa, $options, $component, $filearea, $args, $forcedownload);
         }
-
-        return parent::check_file_access($qa, $options, $component, $filearea,
-            $args, $forcedownload);
     }
 }

--- a/question.php
+++ b/question.php
@@ -154,7 +154,7 @@ class qtype_crossword_question extends question_graded_automatically {
 
     public function clear_wrong_from_response(array $response): array {
         foreach ($this->answers as $key => $answer) {
-            if (isset($response[$this->field($key)]) && !$answer->is_correct($response[$this->field($key)])) {
+            if (isset($response[$this->field($key)]) && !$this->is_full_fraction($answer, $response[$this->field($key)])) {
                 $response[$this->field($key)] = '';
             }
         }

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -96,6 +96,42 @@ class question_test extends \advanced_testcase {
     }
 
     /**
+     * Test clear_wrong_from_response with accent.
+     *
+     * @dataProvider clear_wrong_from_response_with_accent
+     * @covers \qtype_crossword_question::clear_wrong_from_response
+     * @param string $template crosswword template name.
+     * @param array $responses submitted responses.
+     * @param array $expected Expected result.
+     */
+    public function test_clear_wrong_from_response_with_accent(string $template, array $responses, array $expected): void {
+        $question = \test_question_maker::make_question('crossword', $template);
+        $this->assertEquals($expected, $question->clear_wrong_from_response($responses));
+    }
+
+    /**
+     * Data provider for the test_clear_wrong_from_response.
+     *
+     * @coversNothing
+     * @return array
+     */
+    public function clear_wrong_from_response_with_accent(): array {
+
+        return [
+            'Ignore accent' => [
+                'accept_wrong_accents_but_not_subtract_point',
+                ['sub0' => 'PATE', 'sub1' => 'TELEPHONE'],
+                ['sub0' => 'PATE', 'sub1' => 'TELEPHONE']
+            ],
+            'Partial correct answers with accent' => [
+                'accept_wrong_accents_but_subtract_point',
+                ['sub0' => 'PÂTÉ', 'sub1' => 'TELEPHONE'],
+                ['sub0' => 'PÂTÉ', 'sub1' => '']
+            ],
+        ];
+    }
+
+    /**
      * Test function is_gradable_response.
      *
      * @covers \qtype_crossword_question::is_gradable_response


### PR DESCRIPTION
Hi @timhunt 
- I have fixed the issue base on the discussion with Chris in the first commit.

Accented letters must completely match or the answer is wrong
=> It will clear answers that are not 100% correct.
Partial mark if the letters are correct but one or more accents are wrong
=> It will clear answers that are not 100% correct.
Just grade the letters and ignore any accents
=> It will only clear answers that are incorrect(ignore accent).

When doing smoke testing, I found out that we missing the permission check for files in Hint, so I fixed the issue in the second commit as well.
