### PR TITLE
Crossword: Module team just requested if 'Question text' could be mad…

### DIFF
--- a/edit_crossword_form.php
+++ b/edit_crossword_form.php
@@ -57,6 +57,11 @@ class qtype_crossword_edit_form extends question_edit_form {
         $mform->addElement('submit', 'updateform', get_string('updateform', 'qtype_crossword'));
         $mform->registerNoSubmitButton('updateform');
 
+        // Remove required rule for question text.
+        unset($mform->_rules['questiontext']);
+        $key = array_search('questiontext', $mform->_required);
+        unset($mform->_required[$key]);
+
         $this->set_current_grid_setting();
         $this->add_question_section($mform);
 

--- a/templates/crossword_clues.mustache
+++ b/templates/crossword_clues.mustache
@@ -57,7 +57,9 @@
     }
 }}
 
+{{#questiontext}}
 <div class="qtext clearfix"> {{{ questiontext }}}</div>
+{{/questiontext}}
 <div class="qtype_crossword-grid-wrapper">
     <div class="row mx-auto my-3">
         <div class="col-12 wrap-crossword position-relative px-0">

--- a/tests/behat/add.feature
+++ b/tests/behat/add.feature
@@ -157,3 +157,27 @@ Feature: Test creating a Crossword question
       | For any partially correct response | Partially correct feedback.                 |
       | For any incorrect response         | Incorrect feedback.                         |
     Then I should see "crossword-006"
+
+  Scenario: Create a Crossword question without Question text.
+    When I am on the "Course 1" "core_question > course question bank" page logged in as teacher
+    And I add a "Crossword" question filling the form with:
+      | Question name                      | crossword-007               |
+      | Question text                      |                             |
+      | Number of rows                     | 3                           |
+      | Number of columns                  | 3                           |
+      | id_clue_0                          | Clue 1                      |
+      | id_clue_1                          | Clue 2                      |
+      | id_clue_2                          | Clue 3                      |
+      | id_answer_0                        | AAA                         |
+      | id_answer_1                        | BBB                         |
+      | id_answer_2                        | CCC                         |
+      | id_startrow_0                      | 1                           |
+      | id_startrow_1                      | 2                           |
+      | id_startrow_2                      | 3                           |
+      | id_startcolumn_0                   | 0                           |
+      | id_startcolumn_1                   | 0                           |
+      | id_startcolumn_2                   | 0                           |
+      | For any correct response           | Correct feedback            |
+      | For any partially correct response | Partially correct feedback. |
+      | For any incorrect response         | Incorrect feedback.         |
+    Then I should see "crossword-007"

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -77,6 +77,7 @@ class qtype_crossword_test_helper extends question_test_helper {
         $cw->accentgradingtype = qtype_crossword::ACCENT_GRADING_STRICT;
         $cw->accentpenalty = 0;
         $cw->qtype = question_bank::get_qtype('crossword');
+        $cw->generalfeedback = '';
         $answerslist = [
             (object) [
                 'id' => 1,


### PR DESCRIPTION
Hi @timhunt,

I have done the following steps:

- Removed the question text rule in mform.
- Implemented the Behat test.

I have also addressed a warning issue in the Unit test found in the file tests/helper.php.

Here is the screenshot of the warning: 

![image](https://github.com/moodleou/moodle-qtype_crossword/assets/31382675/6f2171e6-04d9-43e6-9f52-72fbf8e40846)

Could you kindly assist me in reviewing these changes? Thank you.
